### PR TITLE
Configure DOM test and add fecharSaudacao test

### DIFF
--- a/fecharSaudacao.js
+++ b/fecharSaudacao.js
@@ -1,0 +1,7 @@
+function fecharSaudacao() {
+  document.getElementById('welcome-banner').style.display = 'none';
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { fecharSaudacao };
+}

--- a/fecharSaudacao.test.js
+++ b/fecharSaudacao.test.js
@@ -1,0 +1,10 @@
+const { fecharSaudacao } = require('./fecharSaudacao');
+
+describe('fecharSaudacao', () => {
+  test('esconde o banner de boas-vindas', () => {
+    document.body.innerHTML = '<div id="welcome-banner" style="display: block;"></div>';
+    fecharSaudacao();
+    const banner = document.getElementById('welcome-banner');
+    expect(banner.style.display).toBe('none');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -137,12 +137,13 @@
   </div>
 </div>
 
-<footer>
-  © 2025 CCS Telecom — Todos os direitos reservados
-</footer>
+  <footer>
+    © 2025 CCS Telecom — Todos os direitos reservados
+  </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
-<script>
+  <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
+  <script src="fecharSaudacao.js"></script>
+  <script>
   function startConfetti() {
     const duration = 2000;
     const end = Date.now() + duration;
@@ -217,10 +218,6 @@
       requestAnimationFrame(animateLights);
     }
     animateLights();
-  }
-
-  function fecharSaudacao() {
-    document.getElementById('welcome-banner').style.display = 'none';
   }
 
   window.onload = () => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "beneficios-ccs250",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add `fecharSaudacao.js` and integrate it into `index.html`
- set up Jest configuration and add a test verifying that `fecharSaudacao` hides the banner

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1f54bafc832aba96bd6c6e1dbc91